### PR TITLE
2.1.5

### DIFF
--- a/wmclient/CHANGELOG.txt
+++ b/wmclient/CHANGELOG.txt
@@ -1,3 +1,8 @@
+2.1.5
+-------------------------------------
+- Updated Gson to version 2.9.0 to solve vulnerability issue
+- Some code cleanup
+
 2.1.4
 -------------------------------------
 - Updated Apache httpclient to fix known vulnerability

--- a/wmclient/pom.xml
+++ b/wmclient/pom.xml
@@ -316,6 +316,25 @@
                             <finalName>wm-client-java</finalName>
                         </configuration>
                     </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <gpgArguments>
+                                <arg>--pinentry-mode</arg>
+                                <arg>loopback</arg>
+                            </gpgArguments>
+                        </configuration>
+                    </plugin>
                 </plugins>
             </build>
         </profile>

--- a/wmclient/pom.xml
+++ b/wmclient/pom.xml
@@ -158,7 +158,7 @@
 
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.7</version>
+                <version>3.2.0</version>
                 <configuration>
                 </configuration>
             </plugin>


### PR DESCRIPTION
- Updated maven plugins to work with most recent java versions and avoid the `Inappropriate ioctl for device` when using GPG